### PR TITLE
Fix UAppCharacterComp update hook for Episode Aigis

### DIFF
--- a/P3R.CostumeFramework/Hooks/CostumeHooks.cs
+++ b/P3R.CostumeFramework/Hooks/CostumeHooks.cs
@@ -65,7 +65,8 @@ internal unsafe class CostumeHooks
             {
                 this.characterCompUpdate = hooks.CreateWrapper<UAppCharacterComp_Update>(result, out _);
 
-                var setCostumeAddress = result + 0x255;
+                // UAppCharacterComp::Update + 0x254 is FF in release (call to vtable), but 75 in episode aigis (jump)
+                var setCostumeAddress = result + (*(byte*)(result + 0x254) == 0x75 ? 0x183 : 0x255);
                 var setCostumePatch = new string[]
                 {
                     "use64",

--- a/P3R.CostumeFramework/ModConfig.json
+++ b/P3R.CostumeFramework/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "P3R.CostumeFramework",
   "ModName": "Costume Framework for P3R",
   "ModAuthor": "zutomayofan50",
-  "ModVersion": "1.6.0",
+  "ModVersion": "1.6.1",
   "ModDescription": "Streamlines and enhances outfit mods!",
   "ModDll": "P3R.CostumeFramework.dll",
   "ModIcon": "Preview.png",


### PR DESCRIPTION
Fixes crashing when trying to enter any field for Episode Aigis update since `UAppCharacterComp::Update`'s hook was broken