### PR TITLE
Custom Party Panel Icons per Costume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Jetbrains IDE
+
+**/.idea/*

--- a/P3R.CostumeFramework.Interfaces/P3R.CostumeFramework.Interfaces.csproj
+++ b/P3R.CostumeFramework.Interfaces/P3R.CostumeFramework.Interfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/P3R.CostumeFramework/Costumes/CostumeFactory.cs
+++ b/P3R.CostumeFramework/Costumes/CostumeFactory.cs
@@ -131,9 +131,9 @@ internal class CostumeFactory
 
         SetCostumeFile(mod, Path.Join(costumeDir, "description.msg"), path => costume.Description = File.ReadAllText(path), SetType.Full);
         
-        SetCostumeFile(mod, Path.Join(costumeDir, "battle-panel.uasset"), path => costume.Config.PartyPanel.BattlePath = path);
-        SetCostumeFile(mod, Path.Join(costumeDir, "camp-panel.uasset"), path => costume.Config.PartyPanel.CampPath = path);
-        SetCostumeFile(mod, Path.Join(costumeDir, "field-panel.uasset"), path => costume.Config.PartyPanel.FieldPath = path);
+        SetCostumeFile(mod, Path.Join(costumeDir, "T_Costume_Battle_Panel.uasset"), path => costume.Config.PartyPanel.BattlePath = path);
+        SetCostumeFile(mod, Path.Join(costumeDir, "T_Costume_Camp_Panel.uasset"), path => costume.Config.PartyPanel.CampPath = path);
+        SetCostumeFile(mod, Path.Join(costumeDir, "T_Costume_Field_Panel.uasset"), path => costume.Config.PartyPanel.FieldPath = path);
     }
 
     private void LoadCostumeRyo(Costume costume, string costumeDir)

--- a/P3R.CostumeFramework/Costumes/CostumeFactory.cs
+++ b/P3R.CostumeFramework/Costumes/CostumeFactory.cs
@@ -66,6 +66,10 @@ internal class CostumeFactory
         if (config.Animation.CritCamera != null) costume.Config.Animation.CritCamera = config.Animation.CritCamera;
         if (config.Animation.CylinderTable != null) costume.Config.Animation.CylinderTable = config.Animation.CylinderTable;
         if (config.Animation.VisualTable != null) costume.Config.Animation.VisualTable = config.Animation.VisualTable;
+
+        if (config.PartyPanel.BattlePath != null) costume.Config.PartyPanel.BattlePath = config.PartyPanel.BattlePath;
+        if (config.PartyPanel.CampPath != null) costume.Config.PartyPanel.CampPath = config.PartyPanel.CampPath;
+        if (config.PartyPanel.FieldPath != null) costume.Config.PartyPanel.FieldPath = config.PartyPanel.FieldPath;
     }
 
     public Costume? CreateFromExisting(Character character, string name, int costumeId)
@@ -126,6 +130,10 @@ internal class CostumeFactory
         SetCostumeFile(mod, Path.Join(costumeDir, "battle.theme.pme"), path => costume.BattleThemeFile = path, SetType.Full);
 
         SetCostumeFile(mod, Path.Join(costumeDir, "description.msg"), path => costume.Description = File.ReadAllText(path), SetType.Full);
+        
+        SetCostumeFile(mod, Path.Join(costumeDir, "battle-panel.uasset"), path => costume.Config.PartyPanel.BattlePath = path);
+        SetCostumeFile(mod, Path.Join(costumeDir, "camp-panel.uasset"), path => costume.Config.PartyPanel.CampPath = path);
+        SetCostumeFile(mod, Path.Join(costumeDir, "field-panel.uasset"), path => costume.Config.PartyPanel.FieldPath = path);
     }
 
     private void LoadCostumeRyo(Costume costume, string costumeDir)

--- a/P3R.CostumeFramework/Costumes/CostumeService.cs
+++ b/P3R.CostumeFramework/Costumes/CostumeService.cs
@@ -26,6 +26,7 @@ internal unsafe class CostumeService
     private readonly CostumeTableService costumeTable;
     private readonly CostumeShellService costumeShells;
     private readonly CostumeAnimsService costumeAnims;
+    private readonly CostumeHeadPanelService costumeHeadPanel;
 
     public CostumeService(
         IUObjects uobjs,
@@ -55,11 +56,13 @@ internal unsafe class CostumeService
         this.weaponService = new(dt, unreal, this.costumeManager, this.costumeHooks);
         this.itemCountHook = new(registry);
         this.costumeNameHook = new(uobjs, unreal, registry);
+        this.costumeHeadPanel = new(this.costumeManager);
 
         this.costumeHooks.OnCostumeChanged += costume =>
         {
             costumeMusic.Refresh(costume);
             costumeAudio.Refresh(costume);
+            // costumeHeadPanel.Refresh(costume);
             //costumeAnims.UpdateCostumeAnims(costume);
         };
     }

--- a/P3R.CostumeFramework/Costumes/CostumeService.cs
+++ b/P3R.CostumeFramework/Costumes/CostumeService.cs
@@ -3,8 +3,11 @@ using P3R.CostumeFramework.Hooks;
 using P3R.CostumeFramework.Hooks.Animations;
 using P3R.CostumeFramework.Hooks.Costumes;
 using P3R.CostumeFramework.Hooks.Services;
+using p3rpc.asyncassetloader.Interfaces;
 using p3rpc.classconstructor.Interfaces;
+using UE.Toolkit.Interfaces;
 using Unreal.ObjectsEmitter.Interfaces;
+using IDataTables = Unreal.ObjectsEmitter.Interfaces.IDataTables;
 
 namespace P3R.CostumeFramework.Costumes;
 
@@ -38,7 +41,12 @@ internal unsafe class CostumeService
         CostumeMusicService costumeMusic,
         CostumeRyoService costumeAudio,
         IObjectMethods objMethods,
-        bool useFemcPlayer)
+        bool useFemcPlayer,
+        IUnrealMemory toolkitMemory,
+        IUnrealObjects toolkitObjects,
+        IUnrealSpawning toolkitSpawning,
+        IAssetLoader assetLoader
+    )
     {
         this.itemEquip = new(registry);
         this.costumeTable = new(dt, unreal, registry, useFemcPlayer);
@@ -56,14 +64,13 @@ internal unsafe class CostumeService
         this.weaponService = new(dt, unreal, this.costumeManager, this.costumeHooks);
         this.itemCountHook = new(registry);
         this.costumeNameHook = new(uobjs, unreal, registry);
-        this.costumeHeadPanel = new(this.costumeManager);
+        this.costumeHeadPanel = new(this.costumeManager, toolkitMemory, toolkitObjects, toolkitSpawning, assetLoader);
 
         this.costumeHooks.OnCostumeChanged += costume =>
         {
             costumeMusic.Refresh(costume);
             costumeAudio.Refresh(costume);
-            // costumeHeadPanel.Refresh(costume);
-            //costumeAnims.UpdateCostumeAnims(costume);
+            this.costumeHeadPanel.Refresh(costume);
         };
     }
 

--- a/P3R.CostumeFramework/Costumes/Models/CostumeConfig.cs
+++ b/P3R.CostumeFramework/Costumes/Models/CostumeConfig.cs
@@ -50,6 +50,8 @@ internal class CostumeConfig
 
     public CostumeAnimationConfig Animation { get; set; } = new();
 
+    public CostumePartyPanel PartyPanel { get; set; } = new();
+
     public string? GetAssetFile(CostumeAssetType assetType)
         => assetType switch
         {
@@ -173,4 +175,11 @@ internal class CostumeAllout
     public string? TextPath { get; set; }
 
     public string? PlgPath { get; set; }
+}
+
+internal class CostumePartyPanel
+{
+    public string? BattlePath { get; set; }
+    public string? CampPath { get; set; }
+    public string? FieldPath { get; set; }
 }

--- a/P3R.CostumeFramework/Hooks/ItemCountHook.cs
+++ b/P3R.CostumeFramework/Hooks/ItemCountHook.cs
@@ -41,7 +41,7 @@ internal class ItemCountHook
                 lock (GetItemNumLock)
                 {
                     GetItemNumSignaturesScanned++;
-                    if (GetItemNumSignaturesScanned == GetItemNumCandidates.Length)
+                    if (GetItemNumSignaturesScanned == GetItemNumCandidates.Length && this.hook == null)
                     {
                         Log.Error($"Failed to find a pattern for GET_ITEM_NUM.");
                     }

--- a/P3R.CostumeFramework/Hooks/Services/CostumeHeadPanelService.cs
+++ b/P3R.CostumeFramework/Hooks/Services/CostumeHeadPanelService.cs
@@ -111,25 +111,25 @@ internal unsafe class CostumeHeadPanelService
         this.toolkitObjects = toolkitObjects;
         this.toolkitSpawning = toolkitSpawning;
         this.assetLoader = assetLoader;
-        ScanHooks.Add(
-            nameof(FCampHeadPanel_SetPlayerTextureIndex),
+        Project.Scans.AddScanHook(
+            nameof(FBattleHeadPanel_UpdateState),
             "4C 8B DC 49 89 4B ?? 55 53 49 8D 6B ??",
-            (hooks, result) => _FBattleHeadPanel_UpdateState = hooks
+            (result, hooks) => _FBattleHeadPanel_UpdateState = hooks
                 .CreateHook<FBattleHeadPanel_UpdateState>(FBattleHeadPanel_UpdateStateImpl, result)
                 .Activate()
         );
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(FCampHeadPanel_SetPlayerTextureIndex),
             "48 89 5C 24 ?? 57 48 83 EC 30 33 FF 89 51 ??",
-            (hooks, result) => _FCampHeadPanel_SetPlayerTextureIndex = hooks
+            (result, hooks) => _FCampHeadPanel_SetPlayerTextureIndex = hooks
                 .CreateHook<FCampHeadPanel_SetPlayerTextureIndex>(FCampHeadPanel_SetPlayerTextureIndexImpl, result)
                 .Activate()
         );
         
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(FFieldHeadPanel_SetPlayerTextureIndex),
             "40 53 48 83 EC 20 44 89 41 ??",
-            (hooks, result) => _FFieldHeadPanel_SetPlayerTextureIndexImpl = hooks
+            (result, hooks) => _FFieldHeadPanel_SetPlayerTextureIndexImpl = hooks
                 .CreateHook<FFieldHeadPanel_SetPlayerTextureIndex>(FFieldHeadPanel_SetPlayerTextureIndexImpl, result)
                 .Activate()
         );

--- a/P3R.CostumeFramework/Hooks/Services/CostumeHeadPanelService.cs
+++ b/P3R.CostumeFramework/Hooks/Services/CostumeHeadPanelService.cs
@@ -1,0 +1,93 @@
+﻿using P3R.CostumeFramework.Costumes;
+using P3R.CostumeFramework.Types;
+using Reloaded.Hooks.Definitions;
+
+namespace P3R.CostumeFramework.Hooks.Services;
+
+internal unsafe class CostumeHeadPanelService
+{
+    private readonly CostumeManager manager;
+    
+    public CostumeHeadPanelService(CostumeManager manager)
+    {
+        this.manager = manager;
+        ScanHooks.Add(
+            nameof(FCampHeadPanel_SetPlayerTextureIndex),
+            "4C 8B DC 49 89 4B ?? 55 53 49 8D 6B ??",
+            (hooks, result) => _FBattleHeadPanel_UpdateState = hooks
+                .CreateHook<FBattleHeadPanel_UpdateState>(FBattleHeadPanel_UpdateStateImpl, result)
+                .Activate()
+        );
+        ScanHooks.Add(
+            nameof(FCampHeadPanel_SetPlayerTextureIndex),
+            "48 89 5C 24 ?? 57 48 83 EC 30 33 FF 89 51 ??",
+            (hooks, result) => _FCampHeadPanel_SetPlayerTextureIndex = hooks
+                .CreateHook<FCampHeadPanel_SetPlayerTextureIndex>(FCampHeadPanel_SetPlayerTextureIndexImpl, result)
+                .Activate()
+        );
+        
+        ScanHooks.Add(
+            nameof(FFieldHeadPanel_SetPlayerTextureIndex),
+            "40 53 48 83 EC 20 44 89 41 ??",
+            (hooks, result) => _FFieldHeadPanel_SetPlayerTextureIndexImpl = hooks
+                .CreateHook<FFieldHeadPanel_SetPlayerTextureIndex>(FFieldHeadPanel_SetPlayerTextureIndexImpl, result)
+                .Activate()
+        );
+    }
+    
+    private delegate void FBattleHeadPanel_UpdateState(FBattleHeadPanel* self, float a2, float a3, float a4, uint a5);
+    
+    private IHook<FBattleHeadPanel_UpdateState>? _FBattleHeadPanel_UpdateState;
+
+    private void FBattleHeadPanel_UpdateStateImpl(FBattleHeadPanel* self, float a2, float a3, float a4, uint a5)
+    {
+        foreach (var costume in manager.GetCurrentCostumes()
+                     .Where(x => x.Character == (Character)self->Super.PlayerId))
+        {
+            if (costume.CostumeId == 1000)
+            {
+                // Log.Debug($"Current PortraitBaseId: {self->PortraitBaseId}");
+                self->PortraitBaseId = 100;
+            }
+        }
+        _FBattleHeadPanel_UpdateState!.OriginalFunction(self, a2, a3, a4, a5);
+    }
+
+    private delegate void FCampHeadPanel_SetPlayerTextureIndex(FBaseHeadPanel* self, int playerId, int panelState, nint a4);
+    
+    private IHook<FCampHeadPanel_SetPlayerTextureIndex>? _FCampHeadPanel_SetPlayerTextureIndex;
+
+    private void FCampHeadPanel_SetPlayerTextureIndexImpl(FBaseHeadPanel* self, int playerId, int panelState,
+        nint a4)
+    {
+        _FCampHeadPanel_SetPlayerTextureIndex!.OriginalFunction(self, playerId, panelState, a4);
+        foreach (var costume in manager.GetCurrentCostumes()
+                     .Where(x => x.Character == (Character)playerId))
+        {
+            if (costume.CostumeId == 1000)
+            {
+                self->Portrait.SpriteIndex = 15;
+            }
+        }
+    }
+    
+    private delegate void FFieldHeadPanel_SetPlayerTextureIndex(FFieldHeadPanel* self, int playerId, int panelState, nint a4);
+    
+    private IHook<FFieldHeadPanel_SetPlayerTextureIndex>? _FFieldHeadPanel_SetPlayerTextureIndexImpl;
+    
+    private void FFieldHeadPanel_SetPlayerTextureIndexImpl(FFieldHeadPanel* self, int playerId, int panelState,
+        nint a4)
+    {
+        _FFieldHeadPanel_SetPlayerTextureIndexImpl!.OriginalFunction(self, playerId, panelState, a4);
+        foreach (var costume in manager.GetCurrentCostumes()
+                     .Where(x => x.Character == (Character)playerId))
+        {
+            if (costume.CostumeId == 1000)
+            {
+                self->Super.Portrait.SpriteIndex = 15;
+                self->portraitShadow0.SpriteIndex = 15;
+                self->portraitShadow1.SpriteIndex = 15;
+            }
+        }
+    }
+}

--- a/P3R.CostumeFramework/Hooks/Services/CostumeHeadPanelService.cs
+++ b/P3R.CostumeFramework/Hooks/Services/CostumeHeadPanelService.cs
@@ -1,16 +1,116 @@
-﻿using P3R.CostumeFramework.Costumes;
-using P3R.CostumeFramework.Types;
+﻿using System.Numerics;
+using System.Runtime.InteropServices;
+using P3R.CostumeFramework.Costumes;
+using P3R.CostumeFramework.Costumes.Models;
+using p3rpc.asyncassetloader.Interfaces;
+// using p3rpc.nativetypes.Interfaces;
 using Reloaded.Hooks.Definitions;
+using RyoTune.Persona3Reload.Types;
+using UE.Toolkit.Core.Types;
+using UE.Toolkit.Core.Types.Unreal.Factories.Interfaces;
+using UE.Toolkit.Core.Types.Unreal.UE5_4_4;
+using UE.Toolkit.Interfaces;
+using FBaseHeadPanel = P3R.CostumeFramework.Types.FBaseHeadPanel;
+using FBattleHeadPanel = P3R.CostumeFramework.Types.FBattleHeadPanel;
+using FFieldHeadPanel = P3R.CostumeFramework.Types.FFieldHeadPanel;
 
 namespace P3R.CostumeFramework.Hooks.Services;
+
+public unsafe class CostumeHeadPanelAssets
+{
+    private UTexture2D** Storage = (UTexture2D**)NativeMemory.AllocZeroed((nuint)sizeof(nint) * 3);
+
+    public UTexture2D* GetBattleTexture() => Storage[0];
+    public UTexture2D* GetCampTexture() => Storage[1];
+    public UTexture2D* GetFieldTexture() => Storage[2];
+
+    public UTexture2D** GetBattleTexturePtr() => Storage;
+    public UTexture2D** GetCampTexturePtr() => Storage + 1;
+    public UTexture2D** GetFieldTexturePtr() => Storage + 2;
+
+    public int BattleSprIndex { get; set; } = -1;
+    public int CampSprIndex { get; set; } = -1;
+    public int FieldSprIndex { get; set; } = -1;
+}
 
 internal unsafe class CostumeHeadPanelService
 {
     private readonly CostumeManager manager;
+    private readonly IUnrealMemory toolkitMemory;
+    private readonly IUnrealObjects toolkitObjects;
+    private readonly IUnrealSpawning toolkitSpawning;
+    private readonly IAssetLoader assetLoader;
+
+    private ToolkitUObject<USprAsset>? SPR_UI_Battle_PartyPanel;
+    private ToolkitUObject<USprAsset>? SPR_UI_Camp_PartyPanel;
+    private ToolkitUObject<USprAsset>? SPR_UI_Field_PartyPanel;
+    private IUObject? CostumeFrameworkAssetLoader;
+
+    private Dictionary<int, CostumeHeadPanelAssets> CostumeAssets = new();
+
+    private static FSprData CreateSpriteInner(float Width, float Height, FVector2D TexStart, FVector2D TexEnd, UTexture2D* Tex)
+    {
+        var ValueOut = new FSprData
+        {
+            Width = Width,
+            Height = Height,
+            U0 = TexStart.X,
+            V0 = TexStart.Y,
+            U1 = TexEnd.X,
+            v1 = TexEnd.Y,
+            Texture = (UTexture*)Tex,
+        };
+        // These could be arrays (fixed works for primitive types) for but toolkit's struct gen doesn't account for that.
+        var RGBA = (uint*)((nint)(&ValueOut) + 0x20);
+        var StretchLen = (ushort*)((nint)(&ValueOut) + 0x30);
+        var ScalingSize = (uint*)((nint)(&ValueOut) + 0x38);
+        for (var i = 0; i < 4; i++)
+        {
+            RGBA[i] = uint.MaxValue;
+            StretchLen[i] = 0;
+            ScalingSize[i % 2] = 0;
+        }
+        return ValueOut;
+    }
+
+    private static FSprData CreateBattleSprite(int Index, UTexture2D* Tex)
+    {
+        // Treat the image as a 4 x 4 grid
+        var PlatformSize = *(int**)((nint)Tex + 0x190); // FTexturePlatformData
+        var Width = PlatformSize[0] / 4; // FTexturePlatformData->SizeX
+        var Height = PlatformSize[1] / 4; // FTexturePlatformData->SizeY
+        var TexStart = new FVector2D
+        {
+            X = Index % 4 / 4f,
+            Y = Index / 4 / 4f
+        };
+        var TexEnd = new FVector2D
+        {
+            X = (Index % 4 + 1) / 4f,
+            Y = (Index + 4) / 4 / 4f
+        };
+        return CreateSpriteInner(Width, Height, TexStart, TexEnd, Tex);
+    }
+
+    private static FSprData CreateSingleSprite(UTexture2D* Tex)
+    {
+        var PlatformSize = *(int**)((nint)Tex + 0x190); // FTexturePlatformData
+        return CreateSpriteInner(
+            PlatformSize[0], 
+            PlatformSize[1], 
+            new FVector2D { X = 0, Y = 0 }, 
+            new FVector2D { X = 1, Y = 1 }, 
+            Tex);
+    }
     
-    public CostumeHeadPanelService(CostumeManager manager)
+    public CostumeHeadPanelService(CostumeManager manager, IUnrealMemory toolkitMemory,
+        IUnrealObjects toolkitObjects, IUnrealSpawning toolkitSpawning, IAssetLoader assetLoader)
     {
         this.manager = manager;
+        this.toolkitMemory = toolkitMemory;
+        this.toolkitObjects = toolkitObjects;
+        this.toolkitSpawning = toolkitSpawning;
+        this.assetLoader = assetLoader;
         ScanHooks.Add(
             nameof(FCampHeadPanel_SetPlayerTextureIndex),
             "4C 8B DC 49 89 4B ?? 55 53 49 8D 6B ??",
@@ -33,6 +133,24 @@ internal unsafe class CostumeHeadPanelService
                 .CreateHook<FFieldHeadPanel_SetPlayerTextureIndex>(FFieldHeadPanel_SetPlayerTextureIndexImpl, result)
                 .Activate()
         );
+        this.toolkitObjects.OnObjectLoadedByName<USprAsset>("SPR_UI_Battle_PartyPanel", x =>
+        {
+            SPR_UI_Battle_PartyPanel = x;
+            foreach (var Costume in CostumeAssets.Values)
+                Costume.BattleSprIndex = -1;
+        });
+        this.toolkitObjects.OnObjectLoadedByName<USprAsset>("SPR_UI_Camp_PartyPanel", x =>
+        {
+            SPR_UI_Camp_PartyPanel = x;
+            foreach (var Costume in CostumeAssets.Values)
+                Costume.CampSprIndex = -1;
+        });
+        this.toolkitObjects.OnObjectLoadedByName<USprAsset>("SPR_UI_Field_PartyPanel", x =>
+        {
+            SPR_UI_Field_PartyPanel = x;
+            foreach (var Costume in CostumeAssets.Values)
+                Costume.FieldSprIndex = -1;
+        });
     }
     
     private delegate void FBattleHeadPanel_UpdateState(FBattleHeadPanel* self, float a2, float a3, float a4, uint a5);
@@ -44,11 +162,9 @@ internal unsafe class CostumeHeadPanelService
         foreach (var costume in manager.GetCurrentCostumes()
                      .Where(x => x.Character == (Character)self->Super.PlayerId))
         {
-            if (costume.CostumeId == 1000)
-            {
-                // Log.Debug($"Current PortraitBaseId: {self->PortraitBaseId}");
-                self->PortraitBaseId = 100;
-            }
+            if (CostumeAssets.TryGetValue(costume.CostumeId, out var CurrentCostume) 
+                && CurrentCostume.BattleSprIndex != -1)
+                self->PortraitBaseId = CurrentCostume.BattleSprIndex;
         }
         _FBattleHeadPanel_UpdateState!.OriginalFunction(self, a2, a3, a4, a5);
     }
@@ -64,10 +180,9 @@ internal unsafe class CostumeHeadPanelService
         foreach (var costume in manager.GetCurrentCostumes()
                      .Where(x => x.Character == (Character)playerId))
         {
-            if (costume.CostumeId == 1000)
-            {
-                self->Portrait.SpriteIndex = 15;
-            }
+            if (CostumeAssets.TryGetValue(costume.CostumeId, out var CurrentCostume) 
+                && CurrentCostume.CampSprIndex != -1)
+                self->Portrait.SpriteIndex = CurrentCostume.CampSprIndex;
         }
     }
     
@@ -82,12 +197,94 @@ internal unsafe class CostumeHeadPanelService
         foreach (var costume in manager.GetCurrentCostumes()
                      .Where(x => x.Character == (Character)playerId))
         {
-            if (costume.CostumeId == 1000)
-            {
-                self->Super.Portrait.SpriteIndex = 15;
-                self->portraitShadow0.SpriteIndex = 15;
-                self->portraitShadow1.SpriteIndex = 15;
-            }
+            if (!CostumeAssets.TryGetValue(costume.CostumeId, out var CurrentCostume) ||
+                CurrentCostume.FieldSprIndex == -1) continue;
+            self->Super.Portrait.SpriteIndex = CurrentCostume.FieldSprIndex;
+            self->portraitShadow0.SpriteIndex = CurrentCostume.FieldSprIndex;
+            self->portraitShadow1.SpriteIndex = CurrentCostume.FieldSprIndex;
         }
+    }
+    
+    private static string MakeAssetPath(string path) => $"{path}.{path.Split("/")[^1]}";
+
+    private void LoadPath(
+        Costume costume, 
+        string Path, 
+        Func<CostumeHeadPanelAssets, nint> TexturePtrCb,
+        Func<CostumeHeadPanelAssets, int> SpriteIndexCb,
+        Action<CostumeHeadPanelAssets> OnLoadedCb)
+    {
+        var Target = TexturePtrCb(CostumeAssets[costume.CostumeId]);
+        var SpriteIndex = SpriteIndexCb(CostumeAssets[costume.CostumeId]);
+        if (Path == null) return;
+        // Target is non-zero once asset is loaded for the first time.
+        if (*(nint*)Target != nint.Zero)
+        {
+            // This would be -1 if the party panel file was loaded again (e.g Switching between Journey and Ep Aigis),
+            // so call the OnLoadedCb again
+            if (SpriteIndex == -1)
+            {
+                OnLoadedCb(CostumeAssets[costume.CostumeId]);
+            }
+            return;
+        }
+        var UPath = MakeAssetPath($"/Game/{Path.Replace('\\', '/')[..Path.LastIndexOf('.')]}");
+        Log.Debug($"[Refresh] Costume {costume.CostumeId}: Path: {UPath}");
+        assetLoader.LoadAsset(
+            CostumeFrameworkAssetLoader!.Ptr, UPath, Target,
+            x =>
+            {
+                toolkitObjects.GUObjectArray.AddToRootSet((*(UObjectBase**)x)->InternalIndex);
+                OnLoadedCb(CostumeAssets[costume.CostumeId]);
+            });
+    }
+
+    public void Refresh(Costume costume)
+    {
+        if (CostumeFrameworkAssetLoader == null)
+            Log.Debug("CostumeHeadPanelService::Refresh: Create asset loader");
+        CostumeFrameworkAssetLoader ??= toolkitSpawning.SpawnObject<UAssetLoader>("CostumeFrameworkAssetLoader", null);
+        toolkitObjects.GUObjectArray.AddToRootSet(CostumeFrameworkAssetLoader!.InternalIndex);
+        CostumeAssets.TryAdd(costume.CostumeId, new());
+        assetLoader.CreateHandle(CostumeFrameworkAssetLoader.Ptr);
+        LoadPath(
+            costume, costume.Config.PartyPanel.BattlePath!, 
+            x => (nint)x.GetBattleTexturePtr(),
+            x => x.BattleSprIndex,
+            CurrentCostume =>
+            {
+                if (CurrentCostume.BattleSprIndex != -1) return;
+                var SprDatas = new TMapDictionary<HashableInt, FSprDataArray>(
+                    (TMap<HashableInt, FSprDataArray>*)(&SPR_UI_Battle_PartyPanel!.Self->SprDatas), toolkitMemory);
+                var SprArray = new TArrayList<FSprData>(&SprDatas.First().Value.Value->SprDatas, toolkitMemory); // this is always 1
+                CurrentCostume.BattleSprIndex = SprArray.Count;
+                for (var i = 0; i < 13; i++)
+                    SprArray.AddValue(CreateBattleSprite(i, CurrentCostume.GetBattleTexture()));
+            });
+        LoadPath(costume, costume.Config.PartyPanel.CampPath!, 
+            x => (nint)x.GetCampTexturePtr(),
+            x => x.CampSprIndex,
+            CurrentCostume =>
+            {
+                if (CurrentCostume.CampSprIndex != -1) return;
+                var SprDatas = new TMapDictionary<HashableInt, FSprDataArray>(
+                    (TMap<HashableInt, FSprDataArray>*)(&SPR_UI_Camp_PartyPanel!.Self->SprDatas), toolkitMemory);
+                var SprArray = new TArrayList<FSprData>(&SprDatas.First().Value.Value->SprDatas, toolkitMemory); // this is always 1
+                CurrentCostume.CampSprIndex = SprArray.Count;
+                SprArray.AddValue(CreateSingleSprite(CurrentCostume.GetCampTexture()));
+            });
+        LoadPath(costume, costume.Config.PartyPanel.FieldPath!, 
+            x => (nint)x.GetFieldTexturePtr(),
+            x => x.FieldSprIndex,
+            CurrentCostume =>
+            {
+                if (CurrentCostume.FieldSprIndex != -1) return;
+                var SprDatas = new TMapDictionary<HashableInt, FSprDataArray>(
+                    (TMap<HashableInt, FSprDataArray>*)(&SPR_UI_Field_PartyPanel!.Self->SprDatas), toolkitMemory);
+                var SprArray = new TArrayList<FSprData>(&SprDatas.First().Value.Value->SprDatas, toolkitMemory); // this is always 1
+                CurrentCostume.FieldSprIndex = SprArray.Count;
+                SprArray.AddValue(CreateSingleSprite(CurrentCostume.GetFieldTexture()));
+            });
+        assetLoader.LoadQueuedAssets(CostumeFrameworkAssetLoader.Ptr);
     }
 }

--- a/P3R.CostumeFramework/Mod.cs
+++ b/P3R.CostumeFramework/Mod.cs
@@ -12,8 +12,11 @@ using Reloaded.Mod.Interfaces.Internal;
 using Ryo.Interfaces;
 using System.Diagnostics;
 using System.Drawing;
+using p3rpc.asyncassetloader.Interfaces;
+using UE.Toolkit.Interfaces;
 using Unreal.AtlusScript.Interfaces;
 using Unreal.ObjectsEmitter.Interfaces;
+using IDataTables = Unreal.ObjectsEmitter.Interfaces.IDataTables;
 
 namespace P3R.CostumeFramework;
 
@@ -47,7 +50,7 @@ public class Mod : ModBase, IExports
         this.modConfig = context.ModConfig;
 
 #if DEBUG
-        Debugger.Launch();
+        // Debugger.Launch();
 #endif
 
         Project.Init(this.modConfig, this.modLoader, this.log);
@@ -62,6 +65,10 @@ public class Mod : ModBase, IExports
         this.modLoader.GetController<IBattleThemesApi>().TryGetTarget(out var battleThemes);
         this.modLoader.GetController<IRyoApi>().TryGetTarget(out var ryo);
         this.modLoader.GetController<IObjectMethods>().TryGetTarget(out var objMethods);
+        this.modLoader.GetController<IUnrealMemory>().TryGetTarget(out var toolkitMemory);
+        this.modLoader.GetController<IUnrealObjects>().TryGetTarget(out var toolkitObjects);
+        this.modLoader.GetController<IUnrealSpawning>().TryGetTarget(out var toolkitSpawning);
+        this.modLoader.GetController<IAssetLoader>().TryGetTarget(out var assetLoader);
 
         var enabledMods = this.modLoader.GetAppConfig().EnabledMods;
         var eoEnabled = enabledMods.Contains("p3r.skins.extendedoutfits");
@@ -72,7 +79,9 @@ public class Mod : ModBase, IExports
         this.costumeDesc = new(atlusAssets!);
         this.costumeMusic = new(bgme!, battleThemes!, this.costumeRegistry);
         this.costumeRyo = new(ryo!);
-        this.costumes = new(uobjects!, unreal!, dataTables!, this.costumeRegistry, this.costumeOverrides, this.costumeDesc, this.costumeMusic, this.costumeRyo, objMethods!, femcEnabled);
+        this.costumes = new(uobjects!, unreal!, dataTables!, this.costumeRegistry, this.costumeOverrides, this.costumeDesc, 
+            this.costumeMusic, this.costumeRyo, objMethods!, femcEnabled, toolkitMemory!, toolkitObjects!, toolkitSpawning!, 
+            assetLoader!);
 
         this.costumeApi = new CostumeApi(costumeRegistry, costumeOverrides);
         this.modLoader.AddOrReplaceController<ICostumeApi>(this.owner, this.costumeApi);

--- a/P3R.CostumeFramework/ModConfig.json
+++ b/P3R.CostumeFramework/ModConfig.json
@@ -170,6 +170,15 @@
             "AssetFileName": "Mod.zip"
           },
           "ReleaseMetadataName": "Reloaded.Universal.FileEmulationFramework.ReleaseMetadata.json"
+        },
+        "p3rpc.asyncassetloader": {
+          "Config": {
+            "UserName": "Rirurin",
+            "RepositoryName": "p3rpc.asyncassetloader",
+            "UseReleaseTag": true,
+            "AssetFileName": "Mod.zip"
+          },
+          "ReleaseMetadataName": "p3rpc.asyncassetloader.ReleaseMetadata.json"
         }
       }
     },
@@ -203,6 +212,7 @@
     "BGME.BattleThemes",
     "BGME.Framework.API",
     "BGME.Framework.P3R",
+    "p3rpc.asyncassetloader",
     "p3rpc.classconstructor",
     "p3rpc.essentials",
     "Reloaded.Memory.SigScan.ReloadedII",
@@ -210,7 +220,8 @@
     "Ryo.Reloaded",
     "Unreal.UE4SS.Reloaded",
     "Unreal.AtlusScript.Reloaded",
-    "Unreal.ObjectsEmitter.Reloaded"
+    "Unreal.ObjectsEmitter.Reloaded",
+    "UE.Toolkit.Reloaded"
   ],
   "OptionalDependencies": [],
   "SupportedAppId": [

--- a/P3R.CostumeFramework/P3R.CostumeFramework.csproj
+++ b/P3R.CostumeFramework/P3R.CostumeFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>12.0</LangVersion>
@@ -58,12 +58,15 @@
 	</ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="p3rpc.asyncassetloader.Interfaces" Version="1.0.0" />
     <PackageReference Include="p3rpc.classconstructor.Interfaces" Version="1.2.0" />
     <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0" />
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
     <PackageReference Include="Ryo.Interfaces" Version="2.4.0" />
+    <PackageReference Include="RyoTune.Persona3Reload.Types" Version="1.0.0" />
     <PackageReference Include="RyoTune.Reloaded" Version="1.0.1" />
+    <PackageReference Include="UE.Toolkit.Interfaces" Version="1.6.5" />
     <PackageReference Include="Unreal.AtlusScript.Interfaces" Version="1.1.0" />
     <PackageReference Include="Unreal.ObjectsEmitter.Interfaces" Version="1.2.3" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />

--- a/P3R.CostumeFramework/Types/FBaseHeadPanel.cs
+++ b/P3R.CostumeFramework/Types/FBaseHeadPanel.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.InteropServices;
+
+namespace P3R.CostumeFramework.Types;
+
+[StructLayout(LayoutKind.Explicit, Pack = 16, Size = 0xCA0)]
+public struct FBaseHeadPanel
+{
+    [FieldOffset(0x0)] public nint Vtable;
+    [FieldOffset(0x10)] public ushort PlayerId;
+    [FieldOffset(0x30)] public FSpriteDrawInstance Portrait;
+}
+
+// FSprDefStruct, SprDefStruct1
+[StructLayout(LayoutKind.Explicit, Size = 0x68)]
+public struct FSpriteDrawInstance
+{
+    [FieldOffset(0x64)] public int SpriteIndex;
+}

--- a/P3R.CostumeFramework/Types/FBattleHeadPanel.cs
+++ b/P3R.CostumeFramework/Types/FBattleHeadPanel.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace P3R.CostumeFramework.Types;
+
+[StructLayout(LayoutKind.Explicit, Pack = 16, Size = 0x4020)]
+public struct FBattleHeadPanel
+{
+    [FieldOffset(0x0)] public FBaseHeadPanel Super; // Size: 0xCA0
+    [FieldOffset(0x1260)] public int PortraitState;
+    [FieldOffset(0x1268)] public int PortraitBaseId;
+    [FieldOffset(0x1270)] public int PortraitExprId;
+}

--- a/P3R.CostumeFramework/Types/FFieldHeadPanel.cs
+++ b/P3R.CostumeFramework/Types/FFieldHeadPanel.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace P3R.CostumeFramework.Types;
+
+[StructLayout(LayoutKind.Explicit, Pack = 16, Size = 0xEF0)]
+public struct FFieldHeadPanel
+{
+    [FieldOffset(0x0)] public FBaseHeadPanel Super;
+    [FieldOffset(0xca0)] public FSpriteDrawInstance cardBlueBgTrans;
+    [FieldOffset(0xd08)] public FSpriteDrawInstance portraitShadow0;
+    [FieldOffset(0xd70)] public FSpriteDrawInstance portraitShadow1;
+}


### PR DESCRIPTION
something mudkip wanted :true:

Adds the option for costumes to include a custom battle, camp and field party panel icon for the character. These are read from `T_Costume_Battle_Panel`, `T_Costume_Camp_Panel` and `T_Costume_Field_Panel`.

This adds some controllers from Unreal Toolkit to conveniently add TArray elements, and also adds a new dependency called [p3rpc.asyncassetloader](https://github.com/rirurin/p3rpc.asyncassetloader) to handle the loading of the texture files.