### PR TITLE
Fix GET_ITEM_NUM signature for latest P3R update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Jetbrains IDE (Rider)
+**/.idea/*

--- a/P3R.CostumeFramework/Hooks/Animations/ObjSpawn.cs
+++ b/P3R.CostumeFramework/Hooks/Animations/ObjSpawn.cs
@@ -15,15 +15,15 @@ public unsafe class ObjSpawn
 
     public ObjSpawn()
     {
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(StaticConstructObject_Internal),
             "48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 54 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC B0 01 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 48 8B 39",
-            (hooks, result) => this.staticConstructObject = hooks.CreateWrapper<StaticConstructObject_Internal>(result, out _));
+            (result, hooks) => this.staticConstructObject = hooks.CreateWrapper<StaticConstructObject_Internal>(result, out _));
 
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(StaticLoadObject),
             "40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC D8 06 00 00",
-            (hooks, result) => this.loadObjHook = hooks.CreateHook<StaticLoadObject>(this.StaticLoadObjectImpl, result).Activate());
+            (result, hooks) => this.loadObjHook = hooks.CreateHook<StaticLoadObject>(this.StaticLoadObjectImpl, result).Activate());
     }
 
     public UObject* StaticLoadObjectImpl(UClass* uclass, UObject* outer, string name)

--- a/P3R.CostumeFramework/Hooks/CostumeHooks.cs
+++ b/P3R.CostumeFramework/Hooks/CostumeHooks.cs
@@ -58,10 +58,10 @@ internal unsafe class CostumeHooks
 
         this.uobjects.FindObject("DatItemCostumeDataAsset", this.SetCostumeData);
 
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(UAppCharacterComp_Update),
             "48 8B C4 48 89 48 ?? 55 41 54 48 8D 68 ?? 48 81 EC 48 01 00 00",
-            (hooks, result) =>
+            (result, hooks) =>
             {
                 this.characterCompUpdate = hooks.CreateWrapper<UAppCharacterComp_Update>(result, out _);
 

--- a/P3R.CostumeFramework/Hooks/Costumes/CostumeTableService.cs
+++ b/P3R.CostumeFramework/Hooks/Costumes/CostumeTableService.cs
@@ -25,10 +25,10 @@ internal unsafe class CostumeTableService
         this.costumes = costumes;
         this.defaultCostumes = new(useFemcPlayer);
 
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             "Use Full DT_Costume",
             "33 DB 48 8D 4D ?? 48 89 5D ?? 48 89 5D ?? 8D 53 ?? 84 C0 74 ?? E8 ?? ?? ?? ?? 8B 55 ?? 8D 7A",
-            (hooks, result) => this.fullDtHook = hooks.CreateAsmHook("use64\nmov rax, 1", result).Activate());
+            (result, hooks) => this.fullDtHook = hooks.CreateAsmHook("use64\nmov rax, 1", result).Activate());
 
         dt.FindDataTable<FAppCharTableRow>("DT_Costume", table =>
         {

--- a/P3R.CostumeFramework/Hooks/FlowFunctions.cs
+++ b/P3R.CostumeFramework/Hooks/FlowFunctions.cs
@@ -10,10 +10,11 @@ internal class FlowFunctions
 
     public FlowFunctions()
     {
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(GET_PARTY),
             "40 53 48 83 EC 20 8B D9 E8 ?? ?? ?? ?? 48 85 C0 75 ?? 48 83 C4 20 5B C3 8B D3 48 8B C8 E8",
-            (hooks, result) => this.GetParty = hooks.CreateWrapper<GET_PARTY>(result, out _));
+            (result, hooks) => this.GetParty = hooks.CreateWrapper<GET_PARTY>(result, out _),  
+            () => {}); // Let this silently fail so people don't freak out about it
     }
 
     public GET_PARTY GetParty { get; private set; }

--- a/P3R.CostumeFramework/Hooks/ItemCountHook.cs
+++ b/P3R.CostumeFramework/Hooks/ItemCountHook.cs
@@ -21,24 +21,41 @@ internal class ItemCountHook
         "4C 8B DC 48 81 EC 88 00 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 44 24 ?? 48 8D 05 ?? ?? ?? ??"
     ];
     private readonly object GetItemNumLock = new();
+    private int GetItemNumSignaturesScanned;
 
     public ItemCountHook(CostumeRegistry registry)
     {
         this.registry = registry;
         foreach (var (Index, Candidate) in GetItemNumCandidates.Select((x, i) => (i, x)))
         {
-            ScanHooks.Add($"GET_ITEM_NUM[{Index}]", Candidate, (hooks, result) =>
+            Project.Scans.AddScanHook($"GET_ITEM_NUM[{Index}]", Candidate, (result, hooks) =>
             {
                 lock (GetItemNumLock)
                 {
+                    GetItemNumSignaturesScanned++;
                     this.hook ??= hooks.CreateHook<FUN_14c15cad0>(this.Hook, result).Activate();
+                }
+            },
+            () =>
+            {
+                lock (GetItemNumLock)
+                {
+                    GetItemNumSignaturesScanned++;
+                    if (GetItemNumSignaturesScanned == GetItemNumCandidates.Length)
+                    {
+                        Log.Error($"Failed to find a pattern for GET_ITEM_NUM.");
+                    }
+                    else
+                    {
+                        Log.Debug($"No matching pattern for GET_ITEM_NUM[{Index}].");
+                    }
                 }
             });
         }
         
-        ScanHooks.Add(nameof(IsAstrea),
+        Project.Scans.AddScanHook(nameof(IsAstrea),
             "48 83 EC 28 E8 ?? ?? ?? ?? 48 85 C0 74 ?? E8 ?? ?? ?? ?? 48 8B C8 E8 ?? ?? ?? ?? 3C 01 0F 94 C0 48 83 C4 28 C3 48 83 C4 28 C3",
-            (hooks, result) => isAstrea = hooks.CreateWrapper<IsAstrea>(result, out _));
+            (result, hooks) => isAstrea = hooks.CreateWrapper<IsAstrea>(result, out _));
     }
 
     private int Hook(int itemId)

--- a/P3R.CostumeFramework/Hooks/ItemCountHook.cs
+++ b/P3R.CostumeFramework/Hooks/ItemCountHook.cs
@@ -15,13 +15,26 @@ internal class ItemCountHook
 
     private readonly CostumeRegistry registry;
 
+    private static string[] GetItemNumCandidates =
+    [
+        "49 89 E3 48 81 EC 88 00 00 00 48 8B 05 ?? ?? ?? ?? 48 31 E0",
+        "4C 8B DC 48 81 EC 88 00 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 44 24 ?? 48 8D 05 ?? ?? ?? ??"
+    ];
+    private readonly object GetItemNumLock = new();
+
     public ItemCountHook(CostumeRegistry registry)
     {
         this.registry = registry;
-        ScanHooks.Add(
-            "GET_ITEM_NUM",
-            "49 89 E3 48 81 EC 88 00 00 00 48 8B 05 ?? ?? ?? ?? 48 31 E0",
-            (hooks, result) => this.hook = hooks.CreateHook<FUN_14c15cad0>(this.Hook, result).Activate());
+        foreach (var (Index, Candidate) in GetItemNumCandidates.Select((x, i) => (i, x)))
+        {
+            ScanHooks.Add($"GET_ITEM_NUM[{Index}]", Candidate, (hooks, result) =>
+            {
+                lock (GetItemNumLock)
+                {
+                    this.hook ??= hooks.CreateHook<FUN_14c15cad0>(this.Hook, result).Activate();
+                }
+            });
+        }
         
         ScanHooks.Add(nameof(IsAstrea),
             "48 83 EC 28 E8 ?? ?? ?? ?? 48 85 C0 74 ?? E8 ?? ?? ?? ?? 48 8B C8 E8 ?? ?? ?? ?? 3C 01 0F 94 C0 48 83 C4 28 C3 48 83 C4 28 C3",

--- a/P3R.CostumeFramework/Hooks/ItemEquip.cs
+++ b/P3R.CostumeFramework/Hooks/ItemEquip.cs
@@ -15,10 +15,10 @@ internal unsafe class ItemEquip
     {
         this.costumes = costumes;
 
-        ScanHooks.Add(
+        Project.Scans.AddScanHook(
             nameof(GetGlobalWork),
             "48 89 5C 24 ?? 57 48 83 EC 20 48 8B 0D ?? ?? ?? ?? 33 DB",
-            (hooks, result) => this.getGlobalWork = hooks.CreateWrapper<GetGlobalWork>(result, out _));
+            (result, hooks) => this.getGlobalWork = hooks.CreateWrapper<GetGlobalWork>(result, out _));
     }
 
     public nint GetCharWork(Character character)

--- a/P3R.CostumeFramework/Mod.cs
+++ b/P3R.CostumeFramework/Mod.cs
@@ -50,7 +50,7 @@ public class Mod : ModBase, IExports
         Debugger.Launch();
 #endif
 
-        Project.Init(this.modConfig, this.modLoader, this.log);
+        Project.Initialize(this.modConfig, this.modLoader, this.log);
         Log.LogLevel = this.config.LogLevel;
 
         this.modLoader.GetController<IStartupScanner>().TryGetTarget(out var scanner);
@@ -76,10 +76,10 @@ public class Mod : ModBase, IExports
 
         this.costumeApi = new CostumeApi(costumeRegistry, costumeOverrides);
         this.modLoader.AddOrReplaceController<ICostumeApi>(this.owner, this.costumeApi);
+
         this.ApplyConfig();
 
         this.modLoader.ModLoaded += this.OnModLoaded;
-        Project.Start();
     }
 
     private void OnModLoaded(IModV1 mod, IModConfigV1 config)

--- a/P3R.CostumeFramework/ModConfig.json
+++ b/P3R.CostumeFramework/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "P3R.CostumeFramework",
   "ModName": "Costume Framework for P3R",
   "ModAuthor": "RyoTune",
-  "ModVersion": "1.10.1",
+  "ModVersion": "1.10.2",
   "ModDescription": "Streamlines and enhances outfit mods!",
   "ModDll": "P3R.CostumeFramework.dll",
   "ModIcon": "Preview.png",

--- a/P3R.CostumeFramework/P3R.CostumeFramework.csproj
+++ b/P3R.CostumeFramework/P3R.CostumeFramework.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="Reloaded.Mod.Interfaces" Version="2.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Reloaded.SharedLib.Hooks" Version="1.9.0" />
     <PackageReference Include="Ryo.Interfaces" Version="2.4.0" />
-    <PackageReference Include="RyoTune.Reloaded" Version="1.0.1" />
+    <PackageReference Include="RyoTune.Reloaded" Version="4.2.1" />
     <PackageReference Include="Unreal.AtlusScript.Interfaces" Version="1.1.0" />
     <PackageReference Include="Unreal.ObjectsEmitter.Interfaces" Version="1.2.3" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />


### PR DESCRIPTION
Fixes an issue in the latest Steam release of P3R where the signature for GET_ITEM_NUM is not found.

For better compatibility with other versions (older/newer and Gamepass), GET_ITEM_NUM accepts multiple signature candidates.